### PR TITLE
Add Demo.Infrastructure project to CorePractice Data Migration Demo

### DIFF
--- a/Demo.sln
+++ b/Demo.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Demo.Domain", "src\Demo.Dom
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Demo.Application", "src\Demo.Application\Demo.Application.csproj", "{D8D12678-5E5C-4B27-9839-42DC5D0BAA18}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Demo.Infrastructure", "src\Demo.Infrastructure\Demo.Infrastructure.csproj", "{A173722C-FE91-46BC-B30E-E616432B6513}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{D8D12678-5E5C-4B27-9839-42DC5D0BAA18}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D8D12678-5E5C-4B27-9839-42DC5D0BAA18}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D8D12678-5E5C-4B27-9839-42DC5D0BAA18}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A173722C-FE91-46BC-B30E-E616432B6513}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A173722C-FE91-46BC-B30E-E616432B6513}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A173722C-FE91-46BC-B30E-E616432B6513}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A173722C-FE91-46BC-B30E-E616432B6513}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Added the Demo.Infrastructure project to support the CorePractice Data Migration Demo.
This layer handles the data access implementation and repository setup following clean architecture principles.

This is part of the initial project setup and will be expanded with database context and migration logic in future commits.