### PR TITLE
Add initial WinForms project for CorePractice Data Migration Demo

### DIFF
--- a/Demo.sln
+++ b/Demo.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Demo.Application", "src\Dem
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Demo.Infrastructure", "src\Demo.Infrastructure\Demo.Infrastructure.csproj", "{A173722C-FE91-46BC-B30E-E616432B6513}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Demo.Presentation.WinForms", "src\Demo.Presentation.WinForms\Demo.Presentation.WinForms.csproj", "{0743A78F-9CDC-4BA6-B196-E0599E86F02F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{A173722C-FE91-46BC-B30E-E616432B6513}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A173722C-FE91-46BC-B30E-E616432B6513}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A173722C-FE91-46BC-B30E-E616432B6513}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0743A78F-9CDC-4BA6-B196-E0599E86F02F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0743A78F-9CDC-4BA6-B196-E0599E86F02F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0743A78F-9CDC-4BA6-B196-E0599E86F02F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0743A78F-9CDC-4BA6-B196-E0599E86F02F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Added the Demo.WinForms project to provide the user interface for the CorePractice Data Migration Demo.

This commit sets up the UI layer, which will later be connected to the application and infrastructure layers following clean architecture principles.